### PR TITLE
Some typos and let-syntax?

### DIFF
--- a/examples/small.dhall
+++ b/examples/small.dhall
@@ -1,6 +1,6 @@
 let types = ./../types.dhall
 
-let defaults = ./../defaults.dhall
+in let defaults = ./../defaults.dhall
 
 in    defaults.Config
     ⫽ { name =

--- a/examples/validated.dhall
+++ b/examples/validated.dhall
@@ -5,7 +5,7 @@
 
 let types = ./../types.dhall
 
-let defaults = ./../defaults.dhall
+in let defaults = ./../defaults.dhall
 
 in    defaults.Config
     ⫽ { AUTOCOMPLETE =

--- a/render/Attributes.dhall
+++ b/render/Attributes.dhall
@@ -1,8 +1,8 @@
 let Prelude = ./../Prelude.dhall
 
-let types = ./../types.dhall
+in let types = ./../types.dhall
 
-let renderAttribute =
+in let renderAttribute =
         λ(name : Text)
       → λ(x : Optional Bool)
       → Optional/fold

--- a/render/Config.dhall
+++ b/render/Config.dhall
@@ -20,59 +20,59 @@
 -}
 let Prelude = ./../Prelude.dhall
 
-let types = ./../types.dhall
+in let types = ./../types.dhall
 
-let renderOptions = ./Options.dhall
+in let renderOptions = ./Options.dhall
 
-let renderOptional =
+in let renderOptional =
         λ(a : Type)
       → λ(f : a → Text)
       → λ(optional : Optional a)
       → Optional/fold a optional Text (λ(x : a) → renderOptions (f x)) ""
 
-let renderNamedOptional =
+in let renderNamedOptional =
         λ(a : Type)
       → λ(f : a → Text)
       → λ(name : Text)
       → renderOptional a (λ(x : a) → "${name}:${f x}")
 
-let renderOptionalText = renderNamedOptional Text (λ(x : Text) → x)
+in let renderOptionalText = renderNamedOptional Text (λ(x : Text) → x)
 
-let renderOptionalCharacter = renderNamedOptional Text (λ(x : Text) → "'${x}'")
+in let renderOptionalCharacter = renderNamedOptional Text (λ(x : Text) → "'${x}'")
 
-let renderOptionalBool =
+in let renderOptionalBool =
         λ(name : Text)
       → renderOptional Bool (λ(enable : Bool) → "${./Bool.dhall enable}${name}")
 
-let renderOptionalNatural = renderNamedOptional Natural Natural/show
+in let renderOptionalNatural = renderNamedOptional Natural Natural/show
 
-let renderList =
+in let renderList =
         λ(a : Type)
       → λ(f : a → Text)
       → Prelude.`Text`.concatMap a (λ(x : a) → "${f x}\n")
 
-let renderOptionalEnabled =
+in let renderOptionalEnabled =
         λ(a : Type)
       → λ(f : a → Text)
       → renderNamedOptional (types.Enabled a) (./Enabled.dhall a f)
 
-let renderOptionalTopLevel =
+in let renderOptionalTopLevel =
         λ(name : Text)
       → λ(x : Optional Text)
       → Optional/fold Text x Text (λ(file : Text) → "${name}=${file}\n") ""
 
-let renderAUTOCOMPLETES = renderList (types.Enabled Text) ./AUTOCOMPLETE.dhall
+in let renderAUTOCOMPLETES = renderList (types.Enabled Text) ./AUTOCOMPLETE.dhall
 
-let renderAlign =
+in let renderAlign =
       renderOptionalEnabled types.Alignment ./Alignment.dhall "align"
 
-let renderAutopickup =
+in let renderAutopickup =
       renderList types.AUTOPICKUP_EXCEPTION ./AUTOPICKUP_EXCEPTION.dhall
 
-let renderDisclose =
+in let renderDisclose =
       renderNamedOptional types.Disclose ./Disclose.dhall "disclose"
 
-let renderMenuColors =
+in let renderMenuColors =
         λ(x : List types.MenuColor)
       →       if Prelude.`List`.null types.MenuColor x
         
@@ -82,48 +82,48 @@ let renderMenuColors =
               OPTIONS=menucolors
               ${renderList types.MenuColor ./MenuColor.dhall x}''
 
-let renderMenuHeadings =
+in let renderMenuHeadings =
       renderNamedOptional
       types.MenuHeadings
       ./MenuHeadings.dhall
       "menu_headings"
 
-let renderMenuStyle =
+in let renderMenuStyle =
       renderNamedOptional types.MenuStyle ./MenuStyle.dhall "menustyle"
 
-let renderMsgWindow =
+in let renderMsgWindow =
       renderNamedOptional types.MsgWindow ./MsgWindow.dhall "msg_window"
 
-let renderNumberPad =
+in let renderNumberPad =
       renderNamedOptional types.NumberPad ./NumberPad.dhall "number_pad"
 
-let renderPetType = renderNamedOptional types.PetType ./PetType.dhall "pettype"
+in let renderPetType = renderNamedOptional types.PetType ./PetType.dhall "pettype"
 
-let renderPickupBurden =
+in let renderPickupBurden =
       renderNamedOptional
       types.PickupBurden
       ./PickupBurden.dhall
       "pickup_burden"
 
-let renderPileLimit =
+in let renderPileLimit =
       renderNamedOptional types.PileLimit ./PileLimit.dhall "pile_limit"
 
-let renderPlayMode =
+in let renderPlayMode =
       renderNamedOptional types.PlayMode ./PlayMode.dhall "playmode"
 
-let renderRunMode = renderNamedOptional types.RunMode ./RunMode.dhall "runmode"
+in let renderRunMode = renderNamedOptional types.RunMode ./RunMode.dhall "runmode"
 
-let renderSortLoot =
+in let renderSortLoot =
       renderNamedOptional types.SortLoot ./SortLoot.dhall "sortloot"
 
-let renderSOUND = renderList types.SOUND ./SOUND.dhall
+in let renderSOUND = renderList types.SOUND ./SOUND.dhall
 
-let renderOptionalSymSet = renderNamedOptional types.SymSet ./SymSet.dhall
+in let renderOptionalSymSet = renderNamedOptional types.SymSet ./SymSet.dhall
 
-let renderWhatisCoord =
+in let renderWhatisCoord =
       renderNamedOptional types.WhatisCoord ./WhatisCoord.dhall "whatis_coord"
 
-let renderWhatisFilter =
+in let renderWhatisFilter =
       renderNamedOptional
       types.WhatisFilter
       ./WhatisFilter.dhall

--- a/render/Disclose.dhall
+++ b/render/Disclose.dhall
@@ -1,10 +1,10 @@
 let Prelude = ./../Prelude.dhall
 
-let types = ./../types.dhall
+in let types = ./../types.dhall
 
-let renderDisclosure = ./Disclosure.dhall
+in let renderDisclosure = ./Disclosure.dhall
 
-let renderOptionalDisclosure =
+in let renderOptionalDisclosure =
         λ(suffix : Text)
       → λ(x : Optional types.Disclosure)
       → Optional/fold

--- a/render/Hilite.dhall
+++ b/render/Hilite.dhall
@@ -11,7 +11,7 @@ in    λ(a : Type)
             (λ(trigger : a) → "/${renderTrigger trigger}")
             ""
       
-      let attributes =
+      in let attributes =
             Optional/fold
             types.Attributes
             hilite.attributes
@@ -19,6 +19,6 @@ in    λ(a : Type)
             (λ(a : types.Attributes) → "&${./Attributes.dhall a}")
             ""
       
-      let color = "/${./Color.dhall hilite.color}"
+      in let color = "/${./Color.dhall hilite.color}"
       
       in  "${trigger}${color}${attributes}"

--- a/render/HiliteStatus.dhall
+++ b/render/HiliteStatus.dhall
@@ -1,6 +1,6 @@
 let Prelude = ./../Prelude.dhall
 
-let types = ./../types.dhall
+in let types = ./../types.dhall
 
 in    λ(x : types.HiliteStatus)
     → let renderHilites =
@@ -14,13 +14,13 @@ in    λ(x : types.HiliteStatus)
                   "hilite_status:${field}${./Hilite.dhall a renderTrigger h}"
               )
       
-      let renderTextualHilites = renderHilites types.Textual ./Textual.dhall
+      in let renderTextualHilites = renderHilites types.Textual ./Textual.dhall
       
-      let renderNumericHilites = renderHilites types.Numeric ./Numeric.dhall
+      in let renderNumericHilites = renderHilites types.Numeric ./Numeric.dhall
       
-      let renderPercentHilites = renderHilites types.Percent ./Percent.dhall
+      in let renderPercentHilites = renderHilites types.Percent ./Percent.dhall
       
-      let renderConditionHilites =
+      in let renderConditionHilites =
             renderHilites types.Condition ./Condition.dhall
       
       in      renderTextualHilites "title" x.title

--- a/render/MenuColor.dhall
+++ b/render/MenuColor.dhall
@@ -3,7 +3,7 @@ let types = ./../types.dhall
 in    λ(x : types.MenuColor)
     → let attributes = ./Attributes.dhall x.attributes
       
-      let suffix =
+      in let suffix =
             Optional/fold
             types.Color
             x.color

--- a/render/Numeric.dhall
+++ b/render/Numeric.dhall
@@ -1,6 +1,6 @@
 let types = ./../types.dhall
 
-let renderComparison = ./Comparison.dhall
+in let renderComparison = ./Comparison.dhall
 
 in    λ(x : types.Numeric)
     → merge

--- a/render/ParanoidConfirmation.dhall
+++ b/render/ParanoidConfirmation.dhall
@@ -1,8 +1,8 @@
 let Prelude = ./../Prelude.dhall
 
-let types = ./../types.dhall
+in let types = ./../types.dhall
 
-let renderConfirmation =
+in let renderConfirmation =
         λ(name : Text)
       → λ(o : Optional Bool)
       → Optional/fold

--- a/render/Percent.dhall
+++ b/render/Percent.dhall
@@ -1,6 +1,6 @@
 let types = ./../types.dhall
 
-let renderComparison = ./Comparison.dhall
+in let renderComparison = ./Comparison.dhall
 
 in    λ(x : types.Percent)
     → merge

--- a/render/Scores.dhall
+++ b/render/Scores.dhall
@@ -1,6 +1,6 @@
 let Prelude = ./../Prelude.dhall
 
-let types = ./../types.dhall
+in let types = ./../types.dhall
 
 in    λ(x : types.Scores)
     → let own =
@@ -11,7 +11,7 @@ in    λ(x : types.Scores)
             (λ(b : Bool) → [ "${./Bool.dhall b}o" ])
             ([] : List Text)
       
-      let around =
+      in let around =
             Optional/fold
             Natural
             x.around
@@ -19,7 +19,7 @@ in    λ(x : types.Scores)
             (λ(n : Natural) → [ "${Natural/show n}a" ])
             ([] : List Text)
       
-      let top =
+      in let top =
             Optional/fold
             Natural
             x.top
@@ -27,7 +27,7 @@ in    λ(x : types.Scores)
             (λ(n : Natural) → [ "${Natural/show n}t" ])
             ([] : List Text)
 
-      let scores = own # around # top
+      in let scores = own # around # top
       
       in  if Prelude.`List`.null Text scores
           then ""

--- a/test.dhall
+++ b/test.dhall
@@ -1,6 +1,6 @@
 let types = ./types.dhall
 
-let defaults = ./defaults.dhall
+in let defaults = ./defaults.dhall
 
 in    defaults.Config
     ⫽ { hilite_status =

--- a/toNetHack.dhall
+++ b/toNetHack.dhall
@@ -1,2 +1,2 @@
--- This is file just a convenient import synonym
+-- This file is just a convenient import synonym
 ./render/Config.dhall

--- a/types.dhall
+++ b/types.dhall
@@ -6,7 +6,7 @@
     ```
     let types = ./types.dhall
 
-    let defaults = ./defaults.dhall
+    in let defaults = ./defaults.dhall
 
     in    defaults.Config
         ⫽ { role = Some { enable = True, value = types.Role.wizard {=} } }

--- a/types/Config.dhall
+++ b/types/Config.dhall
@@ -10,7 +10,7 @@
     { own : Optional Bool, around : Optional Natural, top : Optional Natural }
     ```
 
-    If all of those fields are `None` then the `scores` option will omitted
+    If all of those fields are `None` then the `scores` option will be omitted
     from the generated NetHack configuration file, so there is no need to wrap
     the `Scores` type in yet another `Optional`.
 -}

--- a/types/Hilite.dhall
+++ b/types/Hilite.dhall
@@ -1,5 +1,5 @@
 {- This is a type-level function used within `./HiliteStatus.dhall` to reduce
-   repetition
+   repetition.
 -}
 
 let Color = ./Color.dhall

--- a/types/Hilite.dhall
+++ b/types/Hilite.dhall
@@ -4,7 +4,7 @@
 
 let Color = ./Color.dhall
 
-let Attributes = ./Attributes.dhall
+in let Attributes = ./Attributes.dhall
 
 in    λ(trigger : Type)
     → { trigger :

--- a/types/HiliteStatus.dhall
+++ b/types/HiliteStatus.dhall
@@ -8,7 +8,7 @@
     ```
     let types = ./types.dhall
 
-    let defaults = ./defaults.dhall
+    in let defaults = ./defaults.dhall
 
     in    defaults.Config
         ⫽ { hilite_status =
@@ -48,13 +48,13 @@
 
 let Hilite = ./Hilite.dhall
 
-let Textual = ./Textual.dhall
+in let Textual = ./Textual.dhall
 
-let Numeric = ./Numeric.dhall
+in let Numeric = ./Numeric.dhall
 
-let Percent = ./Percent.dhall
+in let Percent = ./Percent.dhall
 
-let Condition = ./Condition.dhall
+in let Condition = ./Condition.dhall
 
 in  { title :
         List (Hilite Textual)

--- a/types/HiliteStatus.dhall
+++ b/types/HiliteStatus.dhall
@@ -1,6 +1,6 @@
-{-  Each status has a different type of trigger (i.e. `Textual`, `Numeric`,
-    etc.), which ensures that the user can't specify the wrong type of trigger
-    for each option.
+{-  Each status has a different type of trigger (e.g., `Textual`, `Numeric`),
+    which ensures that the user can't specify the wrong type of trigger for
+    each option.
 
     For example, if the user tries to specify a numeric trigger for the title
     field, like this:

--- a/types/NumberPad.dhall
+++ b/types/NumberPad.dhall
@@ -1,6 +1,6 @@
 {- We don't use a number to encode the `number_pad` option since not all
    numbers are valid selections for this option.  Instead we use a union to
-   explicitly enumerate the valid settings with slightly-friendlier names
+   explicitly enumerate the valid settings with slightly-friendlier names.
 -}
 < Letters :
     {}


### PR DESCRIPTION
Going through the files I stumbled over some typos, figured I'd PR instead of creating an issue for such minor things.

One thing that touches a significant number of files is a lack of `in` keywords corresponding to consecutive `let` keywords.
According to the tutorial and my dhall version they're required.
Maybe this changed in a more recent release though?

My `dhall format` also makes quite a few whitespace changes.
Maybe you want to setup a CI job that automatically typechecks and formats all dhall files? I imagine that'd be pretty useful to other people using dhall.