### PR TITLE
replace deprecated Optional/fold with Prelude.Optional.fold

### DIFF
--- a/render/Attributes.dhall
+++ b/render/Attributes.dhall
@@ -5,7 +5,7 @@ let types = ../types.dhall
 let renderAttribute =
         λ(name : Text)
       → λ(x : Optional Bool)
-      → Optional/fold
+      → Prelude.Optional.fold
           Bool
           x
           (List Text)

--- a/render/Config.dhall
+++ b/render/Config.dhall
@@ -28,7 +28,7 @@ let renderOptional =
         λ(a : Type)
       → λ(f : a → Text)
       → λ(optional : Optional a)
-      → Optional/fold a optional Text (λ(x : a) → renderOptions (f x)) ""
+      → Prelude.Optional.fold a optional Text (λ(x : a) → renderOptions (f x)) ""
 
 let renderNamedOptional =
         λ(a : Type)
@@ -65,7 +65,7 @@ let renderOptionalEnabled =
 let renderOptionalTopLevel =
         λ(name : Text)
       → λ(x : Optional Text)
-      → Optional/fold
+      → Prelude.Optional.fold
           Text
           x
           Text

--- a/render/Disclose.dhall
+++ b/render/Disclose.dhall
@@ -7,7 +7,7 @@ let renderDisclosure = ./Disclosure.dhall
 let renderOptionalDisclosure =
         λ(suffix : Text)
       → λ(x : Optional types.Disclosure)
-      → Optional/fold
+      → Prelude.Optional.fold
           types.Disclosure
           x
           (List Text)

--- a/render/Hilite.dhall
+++ b/render/Hilite.dhall
@@ -1,10 +1,11 @@
 let types = ../types.dhall
+let Prelude = ../Prelude.dhall
 
 in    λ(a : Type)
     → λ(renderTrigger : a → Text)
     → λ(hilite : types.Hilite a)
     → let trigger =
-            Optional/fold
+            Prelude.Optional.fold
               a
               hilite.trigger
               Text
@@ -12,7 +13,7 @@ in    λ(a : Type)
               ""
 
       let attributes =
-            Optional/fold
+            Prelude.Optional.fold
               types.Attributes.Type
               hilite.attributes
               Text

--- a/render/MenuColor.dhall
+++ b/render/MenuColor.dhall
@@ -1,10 +1,11 @@
 let types = ../types.dhall
+let Prelude = ../Prelude.dhall
 
 in    λ(x : types.MenuColor)
     → let attributes = ./Attributes.dhall x.attributes
 
       let suffix =
-            Optional/fold
+            Prelude.Optional.fold
               types.Color
               x.color
               Text

--- a/render/ParanoidConfirmation.dhall
+++ b/render/ParanoidConfirmation.dhall
@@ -5,7 +5,7 @@ let types = ../types.dhall
 let renderConfirmation =
         λ(name : Text)
       → λ(o : Optional Bool)
-      → Optional/fold
+      → Prelude.Optional.fold
           Bool
           o
           (List Text)

--- a/render/Scores.dhall
+++ b/render/Scores.dhall
@@ -4,7 +4,7 @@ let types = ../types.dhall
 
 in    λ(x : types.Scores.Type)
     → let own =
-            Optional/fold
+            Prelude.Optional.fold
               Bool
               x.own
               (List Text)
@@ -12,7 +12,7 @@ in    λ(x : types.Scores.Type)
               ([] : List Text)
 
       let around =
-            Optional/fold
+            Prelude.Optional.fold
               Natural
               x.around
               (List Text)
@@ -20,7 +20,7 @@ in    λ(x : types.Scores.Type)
               ([] : List Text)
 
       let top =
-            Optional/fold
+            Prelude.Optional.fold
               Natural
               x.top
               (List Text)


### PR DESCRIPTION
See:
https://docs.dhall-lang.org/howtos/migrations/Deprecation-of-Optional-fold-and-Optional-build.html

This closes issue #3.